### PR TITLE
Don't consider response with {error: null} to be an error.

### DIFF
--- a/jquery.jsonrpcclient.js
+++ b/jquery.jsonrpcclient.js
@@ -125,7 +125,7 @@
       headers  : this.options.headers,
 
       success  : function(data) {
-        if ('error' in data) {
+        if ('error' in data && data.error != null) {
           error_cb(data.error);
         }
         else {


### PR DESCRIPTION
According to http://json-rpc.org/wiki/specification error:

> An Error object if there was an error invoking the method. It must be null if there was no error.
